### PR TITLE
Add extra batchHeaderSize for initial Batch.grow

### DIFF
--- a/internal/batch/batch.go
+++ b/internal/batch/batch.go
@@ -50,7 +50,8 @@ func (b *Batch) grow(n int) (scratch []byte, ok bool) {
 	n += binary.MaxVarintLen64
 	l, z := len(b.data), cap(b.data)
 	if l+n > z {
-		z += z/2 + n
+		// Add batchHeaderSize for initial grow without conditional test.
+		z += z/2 + n + batchHeaderSize
 		buf := make([]byte, l, z)
 		copy(buf, b.data)
 		b.data = buf

--- a/internal/batch/batch_test.go
+++ b/internal/batch/batch_test.go
@@ -38,6 +38,12 @@ var bunchCases = map[string]batchCase{
 			{keys.Value, "\x93\x0a\xc3", "mbiojfasf"},
 		},
 	},
+	"test3": {
+		32423421,
+		[]writeCase{
+			{keys.Delete, "a", ""},
+		},
+	},
 }
 
 func addBatchWrites(t *testing.T, b *batch.Batch, name string, cases []writeCase) {


### PR DESCRIPTION
to fix possible overlapping range between storage for key/value and
scratch buffer.